### PR TITLE
Fixed hw1 typos

### DIFF
--- a/hw1/hw1.md
+++ b/hw1/hw1.md
@@ -36,7 +36,7 @@ Behavioral Cloning
     We recommend that you read the files in the following order. For
     some files, you will need to fill in blanks, labeled `TODO`.
 
-    -   `run_hw1.py`
+    -   `hw1.py`
 
     -   `infrastructure/rl_trainer.py`
 

--- a/hw1/roble/infrastructure/rl_trainer.py
+++ b/hw1/roble/infrastructure/rl_trainer.py
@@ -93,7 +93,6 @@ class RL_Trainer(object):
         except:
             pass
         
-        self.add_wrappers()
         self._agent = agent_class(self._env, **combined_params)
         self._log_video = False
         self._log_metrics = True

--- a/installation.md
+++ b/installation.md
@@ -9,6 +9,7 @@ These installation instructions are created for Ubuntu 20.04. If you are using a
 ```
 sudo apt-get install libosmesa6-dev
 sudo apt-get install patchelf
+sudo apt-get install swig
 ```
 
 ## Install Python Environment


### PR DESCRIPTION
- Added swig to installation as it was required for me to install some dependencies (I'm on Ubuntu 24.04)
- Fixed some typos in README and removed line causing error in RL Trainer